### PR TITLE
feat: lógica da % da bateria

### DIFF
--- a/include/graphics/FlashlightState.h
+++ b/include/graphics/FlashlightState.h
@@ -1,0 +1,9 @@
+#ifndef FLASHLIGHT_STATE_H
+#define FLASHLIGHT_STATE_H
+
+// variáveis globais de estado da lanterna
+extern float flashlightBattery;   // % da bateria
+extern bool flashlightOn;         // se a lanterna está ligada
+extern float batteryDrainRate;    // % por segundo
+
+#endif // FLASHLIGHT_STATE_H

--- a/src/graphics/FlashlightState.cpp
+++ b/src/graphics/FlashlightState.cpp
@@ -1,0 +1,7 @@
+#include "graphics/FlashlightState.h"
+
+// alocação real da memória das variáveis
+float flashlightBattery = 100.0f;   // bateria inicia em 100%
+bool flashlightOn = true;
+float batteryDrainRate = 1.0f;      // duração de %/s -> a cada um segundo, desce um nível da bateria
+                                    // em drawlevel.updateFlashlight() a bateria não desce mais que 25/24 %, pra que o jogador não fique completamente no escuro

--- a/src/graphics/hud.cpp
+++ b/src/graphics/hud.cpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <cstdlib>
 
+#include "graphics/FlashlightState.h"
+
 static void begin2D(int w, int h)
 {
     glMatrixMode(GL_PROJECTION);
@@ -361,8 +363,11 @@ static void drawDoomBar(int w, int h, const HudTextures& tex, const HudState& s)
         glVertex2f(battX, battY + battH);
         glEnd();
 
-        // Barras de carga (4 segmentos verdes - bateria cheia)
+        // Barras de carga (4 segmentos)
         int battSegs = 4;
+        int activeSegs = (int)((flashlightBattery / 100.0f) * battSegs + 0.999f);
+        if(activeSegs > battSegs) activeSegs = battSegs;
+
         float segMargin = px;
         float innerW = battW - segMargin * 2.0f;
         float innerH = battH - segMargin * 2.0f;
@@ -374,8 +379,14 @@ static void drawDoomBar(int w, int h, const HudTextures& tex, const HudState& s)
             float bsx = battX + segMargin + i * (bSegW + bSegGap);
             float bsy = battY + segMargin;
 
-            // Segmento verde (cheio por enquanto)
-            glColor3f(0.15f, 0.85f, 0.15f);
+            if(i < activeSegs) {
+                // Segmento verde cheio
+                glColor3f(0.15f, 0.85f, 0.15f);
+            } else {
+                // Segmento vazio / fraco
+                glColor3f(0.05f, 0.05f, 0.05f);
+            }
+
             glBegin(GL_QUADS);
             glVertex2f(bsx, bsy);
             glVertex2f(bsx + bSegW, bsy);
@@ -383,18 +394,20 @@ static void drawDoomBar(int w, int h, const HudTextures& tex, const HudState& s)
             glVertex2f(bsx, bsy + innerH);
             glEnd();
 
-            // Brilho no topo do segmento
-            float bHighH = innerH * 0.25f;
-            glEnable(GL_BLEND);
-            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            glColor4f(1.0f, 1.0f, 1.0f, 0.20f);
-            glBegin(GL_QUADS);
-            glVertex2f(bsx, bsy + innerH - bHighH);
-            glVertex2f(bsx + bSegW, bsy + innerH - bHighH);
-            glVertex2f(bsx + bSegW, bsy + innerH);
-            glVertex2f(bsx, bsy + innerH);
-            glEnd();
-            glDisable(GL_BLEND);
+            // Brilho apenas nos segmentos ativos
+            if(i < activeSegs) {
+                float bHighH = innerH * 0.25f;
+                glEnable(GL_BLEND);
+                glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+                glColor4f(1.0f, 1.0f, 1.0f, 0.20f);
+                glBegin(GL_QUADS);
+                glVertex2f(bsx, bsy + innerH - bHighH);
+                glVertex2f(bsx + bSegW, bsy + innerH - bHighH);
+                glVertex2f(bsx + bSegW, bsy + innerH);
+                glVertex2f(bsx, bsy + innerH);
+                glEnd();
+                glDisable(GL_BLEND);
+            }
         }
 
         // Raio/relâmpago pixel art no centro (ícone de energia)


### PR DESCRIPTION
* criação do arquivo `FlashlightState.cpp`  e `FlashlightState.h` pra guardar as variáveis globais do estado da lanterna.

* método `drawlevel.setupFlashlight()` modificado pra suportar brilho variável, proporcionando que a iluminação diminua a medida que a bateria diminui.

* método `updateFlashlight()` criado pra atualizar a % da bateria

* hud da lanterna modificado pra que o indicador diminua a medida que a bateria diminui -> bateria não fica abaixo de  25% pro jogador não ficar completamente no escuro (isso pode ser modificado em `drawlevel.updateFlashlight()`).